### PR TITLE
Update Kotlin version to support Flutter 2.10

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group 'be.appmire.flutter_privacy_screen'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.5.31'
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
To be able to use this library with Flutter 2.10, a newer Kotlin version is required. This is mentioned in the Flutter migration guide.

https://docs.flutter.dev/release/breaking-changes/kotlin-version#migration-guide